### PR TITLE
Make TOC an ordered list

### DIFF
--- a/constituents/markup.js
+++ b/constituents/markup.js
@@ -16,13 +16,15 @@ var markup = {
 		} else {
 			result += "    <div class='contents'>[[EOL]]";
 			result += "      <h1>[[CONTENTS]]</h1>[[EOL]]";
+            result += "      <ol>[[EOL]]";
 			for (var i = 1; i <= document.sections.length; i++) {
 				var section = document.sections[i - 1];
 				if (!section.excludeFromContents) {
 					var title = section.title;
-					result += "      <a href='s" + i + ".xhtml'>" + title + "</a><br/>[[EOL]]";
+					result += "      <li class='toc-item'><a href='s" + i + ".xhtml'>" + title + "</a></li>[[EOL]]";
 				}
 			}
+            result += "      </ol>[[EOL]]"
 			result += "    </div>[[EOL]]";
 		}
 		result += "  </body>[[EOL]]";


### PR DESCRIPTION
Hi @kcartlidge!

Really like your library. Was using it and thought this might improve the TOC. 

Whereas before the style was a list of anchor tags:

Eg. 
![image](https://cloud.githubusercontent.com/assets/1745854/14374442/7adf2832-fd1b-11e5-8f60-e41f7c7e1633.png)

This change makes the TOC an ordered list.

Eg. 
![image](https://cloud.githubusercontent.com/assets/1745854/14374454/8888193a-fd1b-11e5-9ec4-5a4a6d3549af.png)

It also adds a class selector to the items in the list so they can be styled with CSS.

Let me know what you think :)
