### PR TITLE
Google Play Books + Zip Archive Fix

### DIFF
--- a/constituents/markup.js
+++ b/constituents/markup.js
@@ -76,7 +76,6 @@ var markup = {
 		result += "    <link rel='schema.DCTYPE' href='http://purl.org/dc/dcmitype/' hreflang='en' />[[EOL]]";
 		result += "    <link rel='schema.DCAM' href='http://purl.org/dc/dcam/' hreflang='en' />[[EOL]]";
 		result += "    <link rel='stylesheet' type='text/css' href='../css/ebook.css' />[[EOL]]";
-		result += "    <base href='.' />[[EOL]]";
 		result += "  </head>[[EOL]]";
 		result += "  <body>[[EOL]]";
 		result += "    <div id='s" + sectionNumber + "'></div>[[EOL]]";

--- a/index.js
+++ b/index.js
@@ -123,7 +123,6 @@ function document(metadata, coverImage, generateContentsCallback) {
 			// Write the file contents.
 			for (var i in files) {
 				if (files[i].folder.length > 0) {
-					archive.append(null, {name: files[i].folder + '/'});
 					archive.append(files[i].content, {name: files[i].folder + '/' + files[i].name, store: !files[i].compress});
 				} else {
 					archive.append(files[i].content, {name: files[i].name, store: !files[i].compress});
@@ -239,4 +238,3 @@ function makeFolder(path) {
 		if (e.code != 'EEXIST') throw e;
 	}
 }
-


### PR DESCRIPTION
Hi @kcartlidge !

`nodepub` had been creating ebooks for me that worked in iBooks and Calibre but no in Google Play Books. There's an upload feature, and attempting to upload a book would yield an error.

![image](https://cloud.githubusercontent.com/assets/1745854/15089866/e5f1b238-13d3-11e6-9d14-9855a06f30f7.png)

I had also noticed that the zip seemed to have a weird structure when I inspected it in my IDE. 

![image](https://cloud.githubusercontent.com/assets/1745854/15089867/f27764bc-13d3-11e6-8cad-fa85f26dba30.png)

Looking through the code, I found null folders were being appended to the archive. I removed that line and it fixed the structure issue.

![image](https://cloud.githubusercontent.com/assets/1745854/15089870/0244b44e-13d4-11e6-9e86-5583b5e6a4bd.png)

However, I still wasn't able to add books to Google Play. I inspected the created book with Calibre and searched for bugs. Calibre suggested `<base href='.' />` was pointing to something that did not exist.

![image](https://cloud.githubusercontent.com/assets/1745854/15089875/0f9179de-13d4-11e6-880b-3c9f3872e568.png)
![image](https://cloud.githubusercontent.com/assets/1745854/15089877/161ce7f2-13d4-11e6-91e1-f333cd05d80f.png)

So I removed that. And now created books can be uploaded to Google Books! 😄 

Let me know if these changes look good or if there's any concerns 👍 .
