### PR TITLE
fix bug when using overrideFilename

### DIFF
--- a/src/constituents/markup.js
+++ b/src/constituents/markup.js
@@ -23,8 +23,8 @@ const markup = {
       for (let i = 1; i <= document.sections.length; i += 1) {
         const section = document.sections[i - 1];
         if (!section.excludeFromContents) {
-          const { title } = section;
-          result += `      <a href='s${i}.xhtml'>${title}</a><br/>[[EOL]]`;
+          const { title, filename } = section;
+          result += `      <a href='${filename}'>${title}</a><br/>[[EOL]]`;
         }
       }
       result += '    </div>[[EOL]]';


### PR DESCRIPTION
Bug fix

This pull request fixes a bug that occurs on the auto generated table of contents page when using `overrideFilename` option on a section.

