### PR TITLE
Allow images to be passed as data rather than on-disk files

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ metadata.images = ['../test/hat.png'];
 This part of the metadata is an array of filenames which locate the source images on your system.
 (I strongly recommend you use relative paths in order to allow for documents being produced on different systems having different folder layouts.)
 
+Alternatively, an image may be an object containing name and data:
+
+``` javascript
+metadata.images = [ { name: 'hat.png', content: hat_image_data } ];
+```
+
+This may be useful when using images sourced from somewhere other than the local filesystem. The cover image may also be an object of this form.
+
 These images are automatically added into the EPUB when it is generated. They always go in an `images` folder internally. As they all go into the same folder they *should have unique filenames*.
 
 To include the images in your content the HTML should refer to this internal folder rather than the original source folder, so for example `<img src="../images/hat.png" />` in the above example.

--- a/src/constituents/markup.js
+++ b/src/constituents/markup.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const replacements = require('./replacements');
+const util = require('../utility');
 
 const markup = {
 
@@ -48,7 +49,7 @@ const markup = {
 
   // Provide the contents of the cover HTML enclosure.
   getCover: (document) => {
-    const coverFilename = path.basename(document.coverImage);
+    const coverFilename = path.basename(util.getImageName(document.coverImage));
     let result = '';
     result += "<?xml version='1.0' encoding='UTF-8' ?>[[EOL]]";
     result += "<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.1//EN'  'http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd'>[[EOL]]";

--- a/src/constituents/structural.js
+++ b/src/constituents/structural.js
@@ -22,7 +22,7 @@ const structural = {
 
   // Provide the contents of the OPF (spine) file.
   getOPF: (document) => {
-    const coverFilename = path.basename(document.coverImage);
+    const coverFilename = path.basename(util.getImageName(document.coverImage));
     let i;
     let result = '';
     result += "<?xml version='1.0' encoding='utf-8'?>[[EOL]]";
@@ -86,8 +86,8 @@ const structural = {
     if (document.metadata.images) {
       for (i = 0; i < document.metadata.images.length; i += 1) {
         const image = document.metadata.images[i];
-        const imageFile = path.basename(image);
-        const imageType = util.getImageType(image);
+        const imageFile = path.basename(util.getImageName(image));
+        const imageType = util.getImageType(util.getImageName(image));
         if (imageType.length > 0) {
           result += `    <item id='img${i}' media-type='${imageType}' href='images/${imageFile}'/>[[EOL]]`;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -103,26 +103,24 @@ const document = (metadata, generateContentsCallback) => {
     }
 
     // Extra images - add filename into content property and prepare for async handling.
+    const coverFilename = path.basename(util.getImageName(self.coverImage));
     if ((typeof self.coverImage) === 'string') {
-      const coverFilename = path.basename(self.coverImage);
       asyncFiles.push({
         name: coverFilename, folder: 'OEBPF/images', compress: true, content: self.coverImage,
       });
     } else {
-      const coverFilename = path.basename(self.coverImage.name);
       syncFiles.push({
         name: coverFilename, folder: 'OEBPF/images', compress: true, content: self.coverImage.content,
       });
     }
     if (self.metadata.images) {
       self.metadata.images.forEach((image) => {
+        const imageFilename = path.basename(util.getImageName(image));
         if ((typeof image) === 'string') {
-          const imageFilename = path.basename(image);
           asyncFiles.push({
             name: imageFilename, folder: 'OEBPF/images', compress: true, content: image,
           });
         } else {
-          const imageFilename = path.basename(image.name);
           syncFiles.push({
             name: imageFilename, folder: 'OEBPF/images', compress: true, content: image.content,
           });

--- a/src/index.js
+++ b/src/index.js
@@ -103,16 +103,30 @@ const document = (metadata, generateContentsCallback) => {
     }
 
     // Extra images - add filename into content property and prepare for async handling.
-    const coverFilename = path.basename(self.coverImage);
-    asyncFiles.push({
-      name: coverFilename, folder: 'OEBPF/images', compress: true, content: self.coverImage,
-    });
+    if ((typeof self.coverImage) === 'string') {
+      const coverFilename = path.basename(self.coverImage);
+      asyncFiles.push({
+        name: coverFilename, folder: 'OEBPF/images', compress: true, content: self.coverImage,
+      });
+    } else {
+      const coverFilename = path.basename(self.coverImage.name);
+      syncFiles.push({
+        name: coverFilename, folder: 'OEBPF/images', compress: true, content: self.coverImage.content,
+      });
+    }
     if (self.metadata.images) {
       self.metadata.images.forEach((image) => {
-        const imageFilename = path.basename(image);
-        asyncFiles.push({
-          name: imageFilename, folder: 'OEBPF/images', compress: true, content: image,
-        });
+        if ((typeof image) === 'string') {
+          const imageFilename = path.basename(image);
+          asyncFiles.push({
+            name: imageFilename, folder: 'OEBPF/images', compress: true, content: image,
+          });
+        } else {
+          const imageFilename = path.basename(image.name);
+          syncFiles.push({
+            name: imageFilename, folder: 'OEBPF/images', compress: true, content: image.content,
+          });
+        }
       });
     }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -34,8 +34,16 @@ const getImageType = (filename) => {
   return imageType;
 };
 
+const getImageName = (image) => {
+  if ((typeof image) === 'string') {
+    return image;
+  }
+  return image.name;
+};
+
 module.exports = {
   forEachAsync,
   makeFolder,
   getImageType,
+  getImageName,
 };


### PR DESCRIPTION
Partially addresses #30. This allows you to pass an object of the form `{ name, content }` anywhere you could previously pass an image filename. These objects don't hit the filesystem, but instead just include the data directly. The content member is passed directly on to the content member of `syncFiles`, so as-is it could be anything acceptable to the archiver append method (probably a Buffer).

This doesn't fully address #30, because the `writeEPUB` method still writes directly to the filesystem. I looked into addressing this; however, the archiver module is poorly documented and seems to be node-only. I can work around this for my own purposes by using the `getFilesForEPUB` method and separately depending on something like JSZip.

nodepub could be made more natively browser-friendly by switching out the archiver dependency for JSZip or another browser-supporting zip solution altogether. I think this would be an improvement, but it would be a bigger change and not necessary here.